### PR TITLE
feat: start dev workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,71 @@
+name: Build
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      #----------------------------------------------
+      #       check-out repo and set-up python
+      #----------------------------------------------
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Set up python
+        id: setup-python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10.9'
+      #----------------------------------------------
+      #  -----  install & configure poetry  -----
+      #----------------------------------------------
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          virtualenvs-path: .venv
+          installer-parallel: true
+
+      #----------------------------------------------
+      #       load cached venv if cache exists
+      #----------------------------------------------
+      - name: Load cached venv
+        id: cached-poetry-dependencies
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
+      #----------------------------------------------
+      #  -----  Install dependencies  -----  
+      # protobuf-compiler, grpcio-tools, make and go 
+      #----------------------------------------------
+      - name: Install protoc and grpcio-tools
+        id : install-protoc
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler make golang-go 
+          python -m pip install grpcio-tools
+          go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+      - name: Build
+        run: |
+          export PATH=$PATH:$(go env GOPATH)/bin
+          make build
+          make run-export-image
+      #----------------------------------------------
+      # -----  Upload artifacts to be used later -----
+      #----------------------------------------------
+      - name: Upload artifacts (1/2)
+        uses: actions/upload-artifact@v2
+        with:
+          name: docker-image-export
+          path: ./harpy.tar
+          retention-days: 1
+      - name: Upload artifacts (2/2)
+        uses: actions/upload-artifact@v2
+        with:
+          name: python-package
+          path: ./dist
+          retention-days: 1

--- a/Makefile
+++ b/Makefile
@@ -107,3 +107,6 @@ run-server:
 
 run-client-example:
 	cd $(PYTHON_PROJECT_ROOT) && $(PYTHON) main.py
+
+run-export-image:
+	$(DOCKER) save harpy:$(RELEASE_VERSION) > harpy.tar


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for building the project and updates the `Makefile` to include a new target for exporting a Docker image. The most important changes include setting up the build workflow, installing dependencies, and adding the `run-export-image` target in the `Makefile`.

### GitHub Actions Workflow Setup:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R1-R71): Added a new workflow to automate the build process. This includes checking out the repository, setting up Python with Poetry, installing necessary dependencies like `protobuf-compiler` and `grpcio-tools`, and building the project.

### Makefile Update:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R110-R112): Added a new `run-export-image` target to export the Docker image to a file named `harpy.tar`.